### PR TITLE
Report names are sometimes not prefixed with micronaut

### DIFF
--- a/japicmp/src/main/resources/META-INF/native-image/japicmp/reflect-config.json
+++ b/japicmp/src/main/resources/META-INF/native-image/japicmp/reflect-config.json
@@ -10,7 +10,8 @@
     "allDeclaredMethods" : true,
     "allPublicMethods" : true,
     "fields" : [
-      { "name" : "rootLocation" }
+      { "name" : "rootLocation" },
+      { "name" : "verbose" }
     ]
   }
 ]


### PR DESCRIPTION
So look for both and use the first one found.

Also adds a debug mode to help see why this stuff doesn't work